### PR TITLE
Changed random matices to use more reasonable values

### DIFF
--- a/js/rand.js
+++ b/js/rand.js
@@ -1,0 +1,36 @@
+(function(){
+  /**
+   * A random seed for the pseudoRandom function.
+   * @private
+   * @type {number}
+   */
+  var randomSeed = 0;
+
+  /**
+   * A constant for the pseudoRandom function
+   * @private
+   * @type {number}
+   */
+  var RANDOM_RANGE = Math.pow(2, 32);
+  var RANDOM_RANGE_PLUS_1 = RANDOM_RANGE + 1;
+
+  /**
+   * Returns a deterministic pseudorandom number between 0 and 1
+   * @return {number} a random number between 0 and 1
+   */
+  pseudoRandom = function() {
+    return (randomSeed =
+            (134775813 * randomSeed + 1) %
+            RANDOM_RANGE) / RANDOM_RANGE_PLUS_1;
+  };
+
+  /**
+   * Resets the pseudoRandom function sequence.
+   */
+  resetPseudoRandom = function() {
+    randomSeed = 0;
+  };
+}());
+
+
+

--- a/matrix_benchmark.html
+++ b/matrix_benchmark.html
@@ -562,7 +562,7 @@
 
         testSet('Inverse', [
           { library: 'glMatrix', test: function(count) {
-            var m1 = glMatrixRandom();
+            var m1 = mat4.perspective(90, 0.5, 1, 1000);
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
               mat4.inverse(m1);
@@ -571,7 +571,7 @@
           }},
 
           { library: 'mjs', test: function(count) {
-           var m1 = mjsRandom();
+           var m1 = M4x4.makePerspective(90, 0.5, 1, 1000);
            var res = mjsRandom();
            var start = Date.now();
            for (var i = 0; i < count; ++i) {
@@ -582,7 +582,8 @@
 
           // { library: 'mjs', test: null },
           { library: 'CanvasMatrix', test: function(count) {
-            var m1 = canvasMatrixRandom();
+            var m1 = new CanvasMatrix4();
+            m1.perspective(90, 0.5, 1, 1000);
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
               m1.invert();
@@ -590,7 +591,7 @@
             return Date.now()-start;
           }},
           { library: 'EWGL', test: function(count) {
-            var m1 = m4x4.I().rand();
+            var m1 = m4x4.makePerspective(90, 0.5, 1, 1000);
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
               m1.inverse();
@@ -598,17 +599,18 @@
             return Date.now()-start;
           }},
           { library: 'TDLMath', test: function(count) {
-            var m1 = tdlMathMatrixRandom();
             var mat4 = tdl.math.matrix4;
+            var m1 = mat4.perspective(Math.PI/2, 0.5, 1, 1000);
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
-              mat4.inverse(m1);
+              m1 = mat4.inverse(m1);
             }
             return Date.now()-start;
           }},
           { library: 'TDLFast', test: function(count) {
             var m1 = tdlMathMatrixRandom();
             var mat4 = tdl.fast.matrix4;
+            mat4.perspective(m1, Math.PI/2, 0.5, 1, 1000);
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
               mat4.inverse(m1, m1);

--- a/matrix_benchmark.html
+++ b/matrix_benchmark.html
@@ -6,6 +6,7 @@
     
     <!-- Common Utilities -->
     <script type="text/javascript" src="sprintf.js"></script>
+    <script type="text/javascript" src="js/rand.js"></script>
 
     <!-- Matrix Libraries -->
     <script type="text/javascript" src="js/glMatrix.js"></script>
@@ -59,7 +60,8 @@
         var totalTime = 0;
         var minTime = 0;
         var maxTime = 0;
-        
+        resetPseudoRandom();
+
         for(var i = 0; i < runCount; ++i) {
           var time = f(internalRunCount);
           if(i == 0) {
@@ -94,57 +96,58 @@
         }, 1);
       }
       
+      function radToDeg(angleInRadians) {
+        return angleInRadians * Math.PI / 180;
+      }
+
       function glMatrixRandom() {
-        return mat4.create([
-          Math.random()*100, Math.random()*100, Math.random()*100, Math.random()*100,
-          Math.random()*100, Math.random()*100, Math.random()*100, Math.random()*100,
-          Math.random()*100, Math.random()*100, Math.random()*100, Math.random()*100,
-          Math.random()*100, Math.random()*100, Math.random()*100, Math.random()*100
-        ]);
+        var m = mat4.create();
+        var axis = vec3.normalize(vec3.create([pseudoRandom(), pseudoRandom(), pseudoRandom()]));
+        mat4.identity(m);
+        mat4.rotate(m, pseudoRandom(), axis, m);
+        mat4.translate(m, [pseudoRandom(), pseudoRandom(), pseudoRandom()]);
+        return m;
       }
-      
+
       function mjsRandom() {
-        return new MJS_FLOAT_ARRAY_TYPE([
-          Math.random()*100, Math.random()*100, Math.random()*100, Math.random()*100,
-          Math.random()*100, Math.random()*100, Math.random()*100, Math.random()*100,
-          Math.random()*100, Math.random()*100, Math.random()*100, Math.random()*100,
-          Math.random()*100, Math.random()*100, Math.random()*100, Math.random()*100
-        ]);
+        var axis = V3.normalize([pseudoRandom(), pseudoRandom(), pseudoRandom()]);
+        var m = M4x4.makeRotate(pseudoRandom(), axis);
+        var m = M4x4.translate([pseudoRandom(), pseudoRandom(), pseudoRandom()], m);
+        return m;
       }
-      
+
       function canvasMatrixRandom() {
-        var cm4 =  new CanvasMatrix4()
-        cm4.load([
-          Math.random()*100, Math.random()*100, Math.random()*100, Math.random()*100,
-          Math.random()*100, Math.random()*100, Math.random()*100, Math.random()*100,
-          Math.random()*100, Math.random()*100, Math.random()*100, Math.random()*100,
-          Math.random()*100, Math.random()*100, Math.random()*100, Math.random()*100
-        ]);
-        return cm4; 
+        var m =  new CanvasMatrix4()
+        var axis = V3.normalize([pseudoRandom(), pseudoRandom(), pseudoRandom()]);
+        m.makeIdentity();
+        m.rotate(radToDeg(pseudoRandom()), axis[0], axis[1], axis[2]);
+        m.translate(pseudoRandom(), pseudoRandom(), pseudoRandom());
+        return m;
       }
-      function j3diMatrixRandom() {
-        return new J3DIMatrix4([
-          Math.random()*100, Math.random()*100, Math.random()*100, Math.random()*100,
-          Math.random()*100, Math.random()*100, Math.random()*100, Math.random()*100,
-          Math.random()*100, Math.random()*100, Math.random()*100, Math.random()*100,
-          Math.random()*100, Math.random()*100, Math.random()*100, Math.random()*100
-        ]);
+
+      function ewglMatrixRandom() {
+        var m = new m4x4;
+        var axis = (new v3([pseudoRandom(), pseudoRandom(), pseudoRandom()])).normalize();
+        m.rotate(pseudoRandom(), axis);
+        m.translate(new v3([pseudoRandom(), pseudoRandom(), pseudoRandom()]));
+        return m;
       }
+
       function tdlMathMatrixRandom() {
-        return [
-          Math.random()*100, Math.random()*100, Math.random()*100, Math.random()*100,
-          Math.random()*100, Math.random()*100, Math.random()*100, Math.random()*100,
-          Math.random()*100, Math.random()*100, Math.random()*100, Math.random()*100,
-          Math.random()*100, Math.random()*100, Math.random()*100, Math.random()*100
-        ];
+        var m = tdl.math.matrix4.identity();
+        var axis = tdl.math.normalize([pseudoRandom(), pseudoRandom(), pseudoRandom()]);
+        tdl.math.matrix4.axisRotate(m, axis, pseudoRandom());
+        tdl.math.matrix4.translate(m, [pseudoRandom(), pseudoRandom(), pseudoRandom()]);
+        return m;
       }
+
       function tdlFastMatrixRandom() {
-        return new Float32Array([
-          Math.random()*100, Math.random()*100, Math.random()*100, Math.random()*100,
-          Math.random()*100, Math.random()*100, Math.random()*100, Math.random()*100,
-          Math.random()*100, Math.random()*100, Math.random()*100, Math.random()*100,
-          Math.random()*100, Math.random()*100, Math.random()*100, Math.random()*100
-        ]);
+        var m = new Float32Array(16);
+        var axis = tdl.math.normalize([pseudoRandom(), pseudoRandom(), pseudoRandom()]);
+        tdl.fast.matrix4.identity(m);
+        tdl.fast.matrix4.axisRotate(m, axis, pseudoRandom());
+        tdl.fast.matrix4.translate(m, [pseudoRandom(), pseudoRandom(), pseudoRandom()]);
+        return m;
       }
       function tdlMathMatrix3Random() {
         return [


### PR DESCRIPTION
The old ones used Math.random()*100 which makes really bogus
matrices. Multiplying 99 times itself 20000 times (the count
for the tests) overflows. The doubles turn into 'infinity'.
So I changed them all to make a more reasonable matrix of the
type that would be seen in a real app.

This is the first patch. 
