### PR TITLE
Here's the patch the adds that each library is producing the same results

### DIFF
--- a/js/tdl/fast.js
+++ b/js/tdl/fast.js
@@ -248,10 +248,10 @@ tdl.fast.negativeVector = function(dst, v) {
 /**
  * Negates a matrix.
  * @param {!tdl.fast.Matrix} dst matrix.
- * @param {!tdl.fast.Matrix} m The matrix.
- * @return {!tdl.fast.Matrix} -m.
+ * @param {!tdl.fast.Matrix} v The matrix.
+ * @return {!tdl.fast.Matrix} -v.
  */
-tdl.fast.negativeMatrix = function(dst, m) {
+tdl.fast.negativeMatrix = function(dst, v) {
   var vLength = v.length;
   for (var i = 0; i < vLength; ++i) {
     dst[i] = -v[i];
@@ -779,10 +779,39 @@ tdl.fast.identity4 = function(dst) {
  * @return {!tdl.fast.Matrix} The transpose of m.
  */
 tdl.fast.transpose4 = function(dst, m) {
-  for (var j = 0; j < 4; ++j) {
-    for (var i = 0; i < 4; ++i)
-      dst[j * 4 + i] = m[i * 4 + j];
-  }
+  var m00 = m[0 * 4 + 0];
+  var m01 = m[0 * 4 + 1];
+  var m02 = m[0 * 4 + 2];
+  var m03 = m[0 * 4 + 3];
+  var m10 = m[1 * 4 + 0];
+  var m11 = m[1 * 4 + 1];
+  var m12 = m[1 * 4 + 2];
+  var m13 = m[1 * 4 + 3];
+  var m20 = m[2 * 4 + 0];
+  var m21 = m[2 * 4 + 1];
+  var m22 = m[2 * 4 + 2];
+  var m23 = m[2 * 4 + 3];
+  var m30 = m[3 * 4 + 0];
+  var m31 = m[3 * 4 + 1];
+  var m32 = m[3 * 4 + 2];
+  var m33 = m[3 * 4 + 3];
+
+  dst[ 0] = m00;
+  dst[ 1] = m10;
+  dst[ 2] = m20;
+  dst[ 3] = m30;
+  dst[ 4] = m01;
+  dst[ 5] = m11;
+  dst[ 6] = m21;
+  dst[ 7] = m31;
+  dst[ 8] = m02;
+  dst[ 9] = m12;
+  dst[10] = m22;
+  dst[11] = m32;
+  dst[12] = m03;
+  dst[13] = m13;
+  dst[14] = m23;
+  dst[15] = m33;
   return dst;
 };
 

--- a/js/tdl/math.js
+++ b/js/tdl/math.js
@@ -217,7 +217,7 @@ tdl.math.resetPseudoRandom = function() {
  * @param {number} n
  */
 tdl.math.randomInt = function(n) {
-  return Math.min(Math.floor(Math.random() * n), n - 1);
+  return Math.floor(Math.random() * n);
 }
 
 /**
@@ -768,7 +768,7 @@ tdl.math.rowMajor.mulMatrixVector = function(m, v) {
   for (var i = 0; i < 4; ++i) {
     r[i] = 0.0;
     for (var j = 0; j < 4; ++j)
-      r[i] += row[i * 4 + j] * v[j];
+      r[i] += m[i * 4 + j] * v[j];
   }
   return r;
 };
@@ -1065,9 +1065,9 @@ tdl.math.rowMajor.mulMatrixMatrix = function(a, b) {
   var r = [];
   for (var i = 0; i < 4; ++i) {
     for (var j = 0; j < 4; ++j) {
-      v[i*4+j] = 0.0;
+      r[i*4+j] = 0.0;
       for (var k = 0; k < 4; ++k)
-        v[i*4+j] += a[i*4+k] * b[k*4+j]; // kth row, jth column.
+        r[i*4+j] += a[i*4+k] * b[k*4+j]; // kth row, jth column.
     }
   }
   return r;
@@ -1085,9 +1085,9 @@ tdl.math.columnMajor.mulMatrixMatrix = function(a, b) {
   var r = [];
   for (var i = 0; i < 4; ++i) {
     for (var j = 0; j < 4; ++j) {
-      v[i*4+j] = 0.0;
+      r[i*4+j] = 0.0;
       for (var k = 0; k < 4; ++k)
-        v[i*4+j] += b[i*4+k] * a[k*4+j]; // kth column, jth row.
+        r[i*4+j] += b[i*4+k] * a[k*4+j]; // kth column, jth row.
     }
   }
   return r;
@@ -1160,9 +1160,10 @@ tdl.math.rowMajor.row = function(m, i) {
  * accessed in [column][row] fashion.
  * @param {!tdl.math.Matrix} m The matrix.
  * @param {number} i The index of the desired row.
+ * @param {number} opt_size Unknown (to dkogan)
  * @return {!tdl.math.Vector} The ith row of m.
  */
-tdl.math.columnMajor.row = function(m, i) {
+tdl.math.columnMajor.row = function(m, i, opt_size) {
   opt_size = opt_size || 4;
   var r = [];
   for (var j = 0; j < opt_size; ++j) {
@@ -1186,10 +1187,39 @@ tdl.math.row = null;
  */
 tdl.math.transpose = function(m) {
   var r = [];
-  for (var j = 0; j < 4; ++j) {
-    for (var i = 0; i < 4; ++i)
-      r[j*4+i] = m[i*4+j];
-  }
+  var m00 = m[0 * 4 + 0];
+  var m01 = m[0 * 4 + 1];
+  var m02 = m[0 * 4 + 2];
+  var m03 = m[0 * 4 + 3];
+  var m10 = m[1 * 4 + 0];
+  var m11 = m[1 * 4 + 1];
+  var m12 = m[1 * 4 + 2];
+  var m13 = m[1 * 4 + 3];
+  var m20 = m[2 * 4 + 0];
+  var m21 = m[2 * 4 + 1];
+  var m22 = m[2 * 4 + 2];
+  var m23 = m[2 * 4 + 3];
+  var m30 = m[3 * 4 + 0];
+  var m31 = m[3 * 4 + 1];
+  var m32 = m[3 * 4 + 2];
+  var m33 = m[3 * 4 + 3];
+
+  r[ 0] = m00;
+  r[ 1] = m10;
+  r[ 2] = m20;
+  r[ 3] = m30;
+  r[ 4] = m01;
+  r[ 5] = m11;
+  r[ 6] = m21;
+  r[ 7] = m31;
+  r[ 8] = m02;
+  r[ 9] = m12;
+  r[10] = m22;
+  r[11] = m32;
+  r[12] = m03;
+  r[13] = m13;
+  r[14] = m23;
+  r[15] = m33;
   return r;
 };
 
@@ -1696,14 +1726,14 @@ tdl.math.matrix4.setIdentity = function(m) {
  * @return {!tdl.math.Matrix4} The perspective matrix.
  */
 tdl.math.matrix4.perspective = function(angle, aspect, near, far) {
-  var f = Math.tan(0.5 * (Math.PI - angle));
-  var range = near - far;
+  var f = Math.tan(Math.PI * 0.5 - 0.5 * angle);
+  var rangeInv = 1.0 / (near - far);
 
   return [
     f / aspect, 0, 0, 0,
     0, f, 0, 0,
-    0, 0, far / range, -1,
-    0, 0, near * far / range, 0
+    0, 0, (near + far) * rangeInv, -1,
+    0, 0, near * far * rangeInv * 2, 0
   ];
 };
 

--- a/matrix_benchmark.html
+++ b/matrix_benchmark.html
@@ -33,6 +33,12 @@
       tdl.require('tdl.fast');
     
       testData = {};
+
+      function debuggerLog(obj) {
+        if (window.console && window.console.log) {
+          window.console.log(obj);
+        }
+      }
       
       function log(html) {
         document.getElementById('logDiv').innerHTML += html + '<br/><br/>'
@@ -63,7 +69,8 @@
         resetPseudoRandom();
 
         for(var i = 0; i < runCount; ++i) {
-          var time = f(internalRunCount);
+          var data = f(internalRunCount);
+          var time = data.time;
           if(i == 0) {
             minTime = time;
             maxTime = time;
@@ -80,14 +87,49 @@
         
         dataLogger[library] = { avg: avg, min: minTime, max: maxTime };
         
+        return data.result;
       }
-      
+
+      function preTest(library, f) {
+        // Repeats each benchmark multiple times to smooth out anomalies
+        // Also tracks min and max times
+
+        if(!f) {
+          return;
+        }
+
+        var internalRunCount = 3;
+        resetPseudoRandom();
+
+        var data = f(internalRunCount);
+        return data.result;
+      }
+
       function testSet(name, tests) {
         testData[name] = {};
         setTimeout(function() {
           logTitle(name);
+          var results = [];
+          var baseResult = null;
           for(var i = 0; i < tests.length; ++i) {
+            var result = preTest(tests[i].library, tests[i].test);
+            results.push(result);
+            if (!baseResult && result) {
+              baseResult= result;
+            }
             test(tests[i].library, tests[i].test, testData[name]);
+          }
+
+          // Compare the results to make sure we are testing the same thing
+          for (var i = 0; i < results.length; ++i) {
+            if (results[i] && !Compare(baseResult, results[i])) {
+              debuggerLog(name);
+              debuggerLog(tests[i].library);
+              debuggerLog(baseResult);
+              debuggerLog(results[i]);
+              log('<strong>' + tests[i].library + ': results do NOT match!!!</strong>');
+              testData[name][tests[i].library].bad = true;
+            }
           }
         }, 1);
         setTimeout(function() { 
@@ -96,8 +138,45 @@
         }, 1);
       }
       
+      var kEpsilon = 0.001;
+      function Compare(a, b, pre) {
+        if (b.m11) {
+          b = [
+            b.m11, b.m12, b.m13, b.m14,
+            b.m21, b.m22, b.m23, b.m24,
+            b.m31, b.m32, b.m33, b.m34,
+            b.m41, b.m42, b.m43, b.m44
+          ];
+        } else if (b.elements) {
+          b = b.elements;
+        }
+        return CompareInner(a, b, '');
+
+        function CompareInner(a, b, pre) {
+          // Check if array.
+          if (typeof(a) === 'number') {
+            if (typeof(b) !== 'number') {
+              return false;
+            }
+            var diff =Math.abs(a - b);
+            if (diff > kEpsilon) {
+              log('<strong>Mismatch: ' + pre + ' ' + a + ' != ' + b + ' diff = ' + diff + '</strong>');
+              return false;
+            }
+          } else if (a.length) {
+            if (a.length !== b.length) return false;
+            for (var i = 0; i < a.length; ++i) {
+              if (!Compare(a[i], b[i], pre + '[' + i.toString() + ']')) return false
+            }
+          } else for (var key in a) {
+            if (!Compare(a[key], b[key], pre + '[' + key + ']')) return false;
+          }
+          return true;
+        }
+      }
+
       function radToDeg(angleInRadians) {
-        return angleInRadians * Math.PI / 180;
+        return angleInRadians * 180 / Math.PI;
       }
 
       function glMatrixRandom() {
@@ -119,9 +198,10 @@
       function canvasMatrixRandom() {
         var m =  new CanvasMatrix4()
         var axis = V3.normalize([pseudoRandom(), pseudoRandom(), pseudoRandom()]);
-        m.makeIdentity();
-        m.rotate(radToDeg(pseudoRandom()), axis[0], axis[1], axis[2]);
-        m.translate(pseudoRandom(), pseudoRandom(), pseudoRandom());
+        var angle = radToDeg(pseudoRandom());
+        var trans = [pseudoRandom(), pseudoRandom(), pseudoRandom()];
+        m.translate(trans[0], trans[1], trans[2]);
+        m.rotate(angle, axis[0], axis[1], axis[2]);
         return m;
       }
 
@@ -149,26 +229,15 @@
         tdl.fast.matrix4.translate(m, [pseudoRandom(), pseudoRandom(), pseudoRandom()]);
         return m;
       }
-      function tdlMathMatrix3Random() {
-        return [
-          Math.random()*100, Math.random()*100, Math.random()*100,
-          Math.random()*100, Math.random()*100, Math.random()*100,
-          Math.random()*100, Math.random()*100, Math.random()*100,
-        ];
-      }
-      function tdlFastMatrix3Random() {
-        return new Float32Array([
-          Math.random()*100, Math.random()*100, Math.random()*100,
-          Math.random()*100, Math.random()*100, Math.random()*100,
-          Math.random()*100, Math.random()*100, Math.random()*100,
-        ]);
-      }
     </script>
     
     
     <style type="text/css">
       body {
         font: 0.8em Verdana,sans-serif;
+      }
+      strong {
+        color: red;
       }
     </style>
   </head>
@@ -210,35 +279,34 @@
             for (var i = 0; i < count; ++i) {
               mat4.multiply(m1, m2);
             }
-            return Date.now()-start;
+            return {time: Date.now()-start, result: m1};
           }},
           { library: 'mjs', test: function(count) {
             var m1 = mjsRandom();
             var m2 = mjsRandom();
-            var res = mjsRandom();
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
-              M4x4.mul(m1, m2, res);
+              M4x4.mul(m1, m2, m1);
             }
-            return Date.now()-start;
+            return {time: Date.now()-start, result: m1};
           }},
           { library: 'CanvasMatrix', test: function(count) {
             var m1 = canvasMatrixRandom();
             var m2 = canvasMatrixRandom();
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
-              m1.multRight(m2);
+              m1.multLeft(m2);
             }
-            return Date.now()-start;
+            return {time: Date.now()-start, result: m1};
           }},
           { library: 'EWGL', test: function(count) {
-            var m1 = m4x4.I().rand();
-            var m2 = m4x4.I().rand();
+            var m1 = ewglMatrixRandom();
+            var m2 = ewglMatrixRandom();
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
               m1.x(m2);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'TDLMath', test: function(count) {
             var m1 = tdlMathMatrixRandom();
@@ -246,9 +314,9 @@
             var mat4 = tdl.math.matrix4;
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
-              mat4.mul(m1, m2);
+              m1 = mat4.mul(m2, m1);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'TDLFast', test: function(count) {
             var m1 = tdlFastMatrixRandom();
@@ -256,9 +324,9 @@
             var mat4 = tdl.fast.matrix4;
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
-              mat4.mul(m1, m1, m2);
+              mat4.mul(m1, m2, m1);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }}
         ]);
 
@@ -270,34 +338,35 @@
             for (var i = 0; i < count; ++i) {
               mat4.translate(m1, v1);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'mjs', test: function(count) {
             var m1 = mjsRandom();
             var v1 = [1, 2, 3];
-            var res = mjsRandom();
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
-              M4x4.translate(v1, m1, res);
+              M4x4.translate(v1, m1, m1);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'CanvasMatrix', test: function(count) {
-            var m1 = canvasMatrixRandom();
+            var m1 = new CanvasMatrix4();
+            var m2 = canvasMatrixRandom();
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
               m1.translate(1, 2, 3);
             }
-            return Date.now()-start;
+            m1.multRight(m2);
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'EWGL', test: function(count) {
-            var m1 = m4x4.I().rand();
+            var m1 = ewglMatrixRandom();
             var v1 = v3.set([1, 2, 3]);
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
               m1.translate(v1);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'TDLMath', test: function(count) {
             var m1 = tdlMathMatrixRandom();
@@ -307,7 +376,7 @@
             for (var i = 0; i < count; ++i) {
               mat4.translate(m1, v1);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'TDLFast', test: function(count) {
             var m1 = tdlMathMatrixRandom();
@@ -317,7 +386,7 @@
             for (var i = 0; i < count; ++i) {
               mat4.translate(m1, v1);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }}
         ]);
 
@@ -329,34 +398,35 @@
             for (var i = 0; i < count; ++i) {
               mat4.scale(m1, v1);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'mjs', test: function(count) {
             var m1 = mjsRandom();
             var v1 = [1, 2, 3];
-            var res = mjsRandom();
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
-              M4x4.scale(v1, m1, res);
+              M4x4.scale(v1, m1, m1);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'CanvasMatrix', test: function(count) {
-            var m1 = canvasMatrixRandom();
+            var m1 = new CanvasMatrix4();
+            var m2 = canvasMatrixRandom();
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
               m1.scale(1, 2, 3);
             }
-            return Date.now()-start;
+            m1.multRight(m2);
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'EWGL', test: function(count) {
-            var m1 = m4x4.I().rand();
+            var m1 = ewglMatrixRandom();
             var v1 = v3.set([1, 2, 3]);
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
               m1.scale(v1);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'TDLMath', test: function(count) {
             var m1 = tdlMathMatrixRandom();
@@ -366,7 +436,7 @@
             for (var i = 0; i < count; ++i) {
               mat4.scale(m1, v1);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'TDLFast', test: function(count) {
             var m1 = tdlMathMatrixRandom();
@@ -376,7 +446,7 @@
             for (var i = 0; i < count; ++i) {
               mat4.scale(m1, v1);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }}
         ]);
 
@@ -389,56 +459,60 @@
             for (var i = 0; i < count; ++i) {
               mat4.rotate(m1, a, v1);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'mjs', test: function(count) {
             var m1 = mjsRandom();
             var v1 = [1, 2, 3];
             var a = Math.PI/2;
-            var res = mjsRandom();
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
-              M4x4.rotate(a, v1, m1, res);
+              M4x4.rotate(a, v1, m1, m1);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'CanvasMatrix', test: function(count) {
-            var m1 = canvasMatrixRandom();
+            var m1 = new CanvasMatrix4();
+            var m2 = canvasMatrixRandom();
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
               m1.rotate(90, 1, 2, 3);
             }
-            return Date.now()-start;
+            m1.multRight(m2);
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'EWGL', test: function(count) {
-            var m1 = m4x4.I().rand();
+            var m1 = ewglMatrixRandom();
             var v1 = v3.set([1, 2, 3]);
             var a = Math.PI/2;
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
-              m1.rotate(a, v1);
+              m1.rotate(a, v1, m1);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'TDLMath', test: function(count) {
             var m1 = tdlMathMatrixRandom();
-            var v1 = [1, 2, 3];
-            var start = Date.now();
+            var v1 = tdl.math.normalize([1, 2, 3]);
             var mat4 = tdl.math.matrix4;
+            var a = Math.PI/2;
+            var start = Date.now();
             for (var i = 0; i < count; ++i) {
-              mat4.axisRotate(m1, v1, 90);
+              mat4.axisRotate(m1, v1, a);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'TDLFast', test: function(count) {
             var m1 = tdlMathMatrixRandom();
             var v1 = new Float32Array([1, 2, 3]);
-            var start = Date.now();
+            tdl.fast.normalize(v1, v1);
             var mat4 = tdl.fast.matrix4;
+            var a = Math.PI/2;
+            var start = Date.now();
             for (var i = 0; i < count; ++i) {
-              mat4.axisRotate(m1, v1, 90);
+              mat4.axisRotate(m1, v1, a);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }}
         ]);
 
@@ -451,58 +525,57 @@
             for (var i = 0; i < count; ++i) {
               mat4.rotate(m1, a, v1);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'mjs', test: function(count) {
             var m1 = mjsRandom();
             var v1 = [1, 0, 0];
             var a = Math.PI/2;
-            var res = mjsRandom();
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
-              M4x4.rotate(a, v1, m1, res);
+              M4x4.rotate(a, v1, m1, m1);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'CanvasMatrix', test: function(count) {
-            var m1 = canvasMatrixRandom();
+            var m1 = new CanvasMatrix4();
+            var m2 = canvasMatrixRandom();
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
               m1.rotate(90, 1, 0, 0);
             }
-            return Date.now()-start;
+            m1.multRight(m2);
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'EWGL', test: function(count) {
-            var m1 = m4x4.I().rand();
+            var m1 = ewglMatrixRandom();
             var v1 = v3.set([1, 0, 0]);
             var a = Math.PI/2;
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
               m1.rotate(a, v1);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'TDLMath', test: function(count) {
             var m1 = tdlMathMatrixRandom();
-            var v1 = [1, 2, 3];
             var a = Math.PI/2;
             var mat4 = tdl.math.matrix4;
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
               mat4.rotateX(m1, a);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'TDLFast', test: function(count) {
             var m1 = tdlMathMatrixRandom();
-            var v1 = new Float32Array([1, 2, 3]);
             var a = Math.PI/2;
             var mat4 = tdl.fast.matrix4;
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
               mat4.rotateX(m1, a);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }}
         ]);
 
@@ -513,16 +586,15 @@
             for (var i = 0; i < count; ++i) {
               mat4.transpose(m1);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'mjs', test: function(count) {
             var m1 = mjsRandom();
-            var res = mjsRandom();
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
-              M4x4.transpose(m1, res);
+              M4x4.transpose(m1, m1);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'CanvasMatrix', test: function(count) {
             var m1 = canvasMatrixRandom();
@@ -530,24 +602,24 @@
             for (var i = 0; i < count; ++i) {
               m1.transpose();
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'EWGL', test: function(count) {
-            var m1 = m4x4.I().rand();
+            var m1 = ewglMatrixRandom();
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
               m1.transpose();
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'TDLMath', test: function(count) {
             var m1 = tdlMathMatrixRandom();
             var mat4 = tdl.math.matrix4;
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
-              mat4.transpose(m1);
+              m1 = mat4.transpose(m1);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'TDLFast', test: function(count) {
             var m1 = tdlMathMatrixRandom();
@@ -556,7 +628,7 @@
             for (var i = 0; i < count; ++i) {
               mat4.transpose(m1, m1);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }}
         ]);
 
@@ -567,20 +639,16 @@
             for (var i = 0; i < count; ++i) {
               mat4.inverse(m1);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }},
-
           { library: 'mjs', test: function(count) {
            var m1 = M4x4.makePerspective(90, 0.5, 1, 1000);
-           var res = mjsRandom();
            var start = Date.now();
            for (var i = 0; i < count; ++i) {
-             M4x4.inverseOrthonormal(m1, res);
+             M4x4.inverseOrthonormal(m1, m1);
            }
-           return Date.now()-start;
+           return {time:Date.now()-start, result: m1};
           }},
-
-          // { library: 'mjs', test: null },
           { library: 'CanvasMatrix', test: function(count) {
             var m1 = new CanvasMatrix4();
             m1.perspective(90, 0.5, 1, 1000);
@@ -588,7 +656,7 @@
             for (var i = 0; i < count; ++i) {
               m1.invert();
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'EWGL', test: function(count) {
             var m1 = m4x4.makePerspective(90, 0.5, 1, 1000);
@@ -596,7 +664,7 @@
             for (var i = 0; i < count; ++i) {
               m1.inverse();
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'TDLMath', test: function(count) {
             var mat4 = tdl.math.matrix4;
@@ -605,7 +673,7 @@
             for (var i = 0; i < count; ++i) {
               m1 = mat4.inverse(m1);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'TDLFast', test: function(count) {
             var m1 = tdlMathMatrixRandom();
@@ -615,7 +683,7 @@
             for (var i = 0; i < count; ++i) {
               mat4.inverse(m1, m1);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }}
         ]);
 
@@ -626,8 +694,9 @@
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
               mat4.toInverseMat3(m1, res);
+              mat3.toMat4(res, m1);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'mjs', test: function(count) {
             var m1 = mjsRandom();
@@ -635,50 +704,51 @@
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
               M4x4.inverseTo3x3(m1, res);
+              m1[0] = res[0];
+              m1[1] = res[1];
+              m1[2] = res[2];
+              m1[3] = 0;
+              m1[4] = res[3];
+              m1[5] = res[4];
+              m1[6] = res[5];
+              m1[7] = 0;
+              m1[8] = res[6];
+              m1[9] = res[7];
+              m1[10] = res[8];
+              m1[11] = 0;
+              m1[12] = 0;
+              m1[13] = 0;
+              m1[14] = 0;
+              m1[15] = 1;              
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: m1};
           }},
           { library: 'CanvasMatrix', test: null },
           { library: 'EWGL', test: null },
           { library: 'TDLMath', test: function(count) {
-            var m1 = tdlMathMatrix3Random();
+            var m1 = tdl.math.matrix4.getUpper3x3(tdlMathMatrixRandom());
             var math = tdl.math;
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
-              math.inverse3(m1);
+              m1 = math.inverse3(m1);
             }
-            return Date.now()-start;
+            var m2 = tdl.math.matrix4.identity();
+            tdl.math.matrix4.setUpper3x3(m2, m1);
+            return {time:Date.now()-start, result: m2};
           }},
-          { library: 'TDLFast', test: function(count) {
-            var m1 = tdlMathMatrix3Random();
-            var math = tdl.math;
-            var start = Date.now();
-            for (var i = 0; i < count; ++i) {
-              math.inverse3(m1, m1);
-            }
-            return Date.now()-start;
-          }}
+          { library: 'TDLFast', test: null}
         ]);
 
         testSet('Vector Transformation', [
-          { library: 'glMatrix', test: function(count) {
-            var m1 = glMatrixRandom();
-            var v1 = [1, 2, 3];
-            var start = Date.now();
-            for (var i = 0; i < count; ++i) {
-              mat4.multiplyVec3(m1, v1);
-            }
-            return Date.now()-start;
-          }},
+          { library: 'glMatrix', test: null},
           { library: 'mjs', test: function(count) {
             var m1 = mjsRandom();
             var v1 = [1, 2, 3];
-            var res = [1, 2, 3];
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
-              V3.mul4x4(m1, v1, res);
+              V3.mul4x4(m1, v1, v1);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: v1};
           }},
           { library: 'CanvasMatrix', test: null },
           { library: 'EWGL', test: null },
@@ -688,9 +758,9 @@
             var mat4 = tdl.math.matrix4;
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
-              mat4.transformPoint(m1, v1);
+              v1 = mat4.transformPoint(m1, v1);
             }
-            return Date.now()-start;
+            return {time:Date.now()-start, result: v1};
           }},
           { library: 'TDLFast', test: null }
         ]);
@@ -811,6 +881,9 @@
             data = document.getElementById(benchmark + '_' + library_to_id(library) + '_data');
             value = testData[benchmark][library].avg;
             data.textContent = value;
+            if (testData[benchmark][library].bad) {
+              data.textContent += "(bad)";
+            }
             average = averages[library];
             if (typeof(average) === "number" && typeof(value) === "number") {
                averages[library] = (average + value) / 2;


### PR DESCRIPTION
```
Added results checking

It was important to make sure each test is actually getting the
same results as the other libraries otherwise we aren't testing
the same thing and the results are INVALID.

Several issues came up while doing this.

1) CanvasMatrix multiplies on the right where as all the other
libraries multiply on the left. In other words, in other
libraries you do this

  m.identity();
  m.translate();
  m.rotateX();
  m.rotateY();
  m.scale();

Where as in CanvasMatrix you'd have to do this

  m.identity();
  m.scale();
  m.rotateY();
  m.rotateX();
  m.translate();

That means in order to get the tests to come out the same an extra
matrix multiply is needed for most of the CanvasMatrix tests.

Another issue that came up is the Vector Transform test is only
testing 2 libraries. The glMatrix library's vector transform is
mostly bogus. It either does a transform that is only useful in
world space (ie, you can't use it to transform through clipspace)
or it does another one (vec4) that makes absolutely no sense
AFAIK. The short of that is it's vector transform is not
comparible to any other libraries. That leaves only mjs and
tdlMath to be compared. I'm not sure why their results do not
match.

Finally, now that the check is in it shows the the mjs inverse
test is invalid. Arguably mjs should be removed from that test
since it's inverse is limited. None of the other libraries
have the limited form of inverse so there's nothing to compare
it to.
```
