### PR TITLE
Updates many tests to use that library's native vector format

### DIFF
--- a/matrix_benchmark.html
+++ b/matrix_benchmark.html
@@ -356,7 +356,7 @@
         testSet('Translation', [
           { library: 'glMatrix', test: function(count) {
             var m1 = glMatrixRandom();
-            var v1 = [1, 2, 3];
+            var v1 = vec3.create([1, 2, 3]);
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
               mat4.translate(m1, v1);
@@ -365,7 +365,7 @@
           }},
           { library: 'mjs', test: function(count) {
             var m1 = mjsRandom();
-            var v1 = [1, 2, 3];
+            var v1 = V3.$(1, 2, 3);
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
               M4x4.translate(v1, m1, m1);
@@ -384,7 +384,7 @@
           }},
           { library: 'EWGL', test: function(count) {
             var m1 = ewglMatrixRandom();
-            var v1 = v3.set([1, 2, 3]);
+            var v1 = new v3([1, 2, 3]);
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
               m1.translate(v1);
@@ -426,7 +426,7 @@
         testSet('Scaling', [
           { library: 'glMatrix', test: function(count) {
             var m1 = glMatrixRandom();
-            var v1 = [1, 2, 3];
+            var v1 = vec3.create([1, 2, 3]);
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
               mat4.scale(m1, v1);
@@ -435,7 +435,7 @@
           }},
           { library: 'mjs', test: function(count) {
             var m1 = mjsRandom();
-            var v1 = [1, 2, 3];
+            var v1 = V3.$(1, 2, 3);
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
               M4x4.scale(v1, m1, m1);
@@ -454,7 +454,7 @@
           }},
           { library: 'EWGL', test: function(count) {
             var m1 = ewglMatrixRandom();
-            var v1 = v3.set([1, 2, 3]);
+            var v1 = new v3([1, 2, 3]);
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
               m1.scale(v1);
@@ -496,7 +496,7 @@
         testSet('Rotation (Arbitrary axis)', [
           { library: 'glMatrix', test: function(count) {
             var m1 = glMatrixRandom();
-            var v1 = [1, 2, 3];
+            var v1 = vec3.create([1, 2, 3]);
             var a = Math.PI/2;
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
@@ -506,7 +506,7 @@
           }},
           { library: 'mjs', test: function(count) {
             var m1 = mjsRandom();
-            var v1 = [1, 2, 3];
+            var v1 = V3.$(1, 2, 3);
             var a = Math.PI/2;
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
@@ -526,7 +526,7 @@
           }},
           { library: 'EWGL', test: function(count) {
             var m1 = ewglMatrixRandom();
-            var v1 = v3.set([1, 2, 3]);
+            var v1 = new v3([1, 2, 3]);
             var a = Math.PI/2;
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
@@ -574,7 +574,7 @@
         testSet('Rotation (X axis)', [
           { library: 'glMatrix', test: function(count) {
             var m1 = glMatrixRandom();
-            var v1 = [1, 0, 0];
+            var v1 = vec3.create([1, 0, 0]);
             var a = Math.PI/2;
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
@@ -584,7 +584,7 @@
           }},
           { library: 'mjs', test: function(count) {
             var m1 = mjsRandom();
-            var v1 = [1, 0, 0];
+            var v1 = V3.$(1, 0, 0);
             var a = Math.PI/2;
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
@@ -604,7 +604,7 @@
           }},
           { library: 'EWGL', test: function(count) {
             var m1 = ewglMatrixRandom();
-            var v1 = v3.set([1, 0, 0]);
+            var v1 = new v3([1, 0, 0]);
             var a = Math.PI/2;
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
@@ -846,7 +846,7 @@
           { library: 'glMatrix', test: null},
           { library: 'mjs', test: function(count) {
             var m1 = mjsRandom();
-            var v1 = [1, 2, 3];
+            var v1 = V3.$(1, 2, 3);
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
               V3.mul4x4(m1, v1, v1);


### PR DESCRIPTION
Before most of the tests were using JavaScript arrays for
the vector used in the loops. For example m4.translate was
being passed a JavaScript array.

But arguably those should be passed a vector specific to
that library so I made it do that. Some of the libraries
should show improved perf on FF and Chrome 12/13.
