### PR TITLE
This fixes the mjs vector transform issue

### DIFF
--- a/matrix_benchmark.html
+++ b/matrix_benchmark.html
@@ -847,9 +847,13 @@
           { library: 'mjs', test: function(count) {
             var m1 = mjsRandom();
             var v1 = V3.$(1, 2, 3);
+            var v2 = V3.$();
             var start = Date.now();
             for (var i = 0; i < count; ++i) {
-              V3.mul4x4(m1, v1, v1);
+              V3.mul4x4(m1, v1, v2);
+              var t = v1;
+              v1 = v2;
+              v2 = t;
             }
             return {time:Date.now()-start, result: v1};
           }},


### PR DESCRIPTION
The result and the vector being transformed can not be the same object.

Now all the test pass except mjs inverse for reasons previously stated
