### PR TITLE
Adjusts the vertical range of the graph.

### DIFF
--- a/matrix_benchmark.html
+++ b/matrix_benchmark.html
@@ -907,6 +907,7 @@
           var benchmarkIndex, libraryIndex;
           benchmarkIndex = 0;
           var x_axis_tics = [];
+          var maxTime = 0;
           for (benchmark in testData) {
             benchmarks.push(benchmark);
             libraryIndex = 0;
@@ -918,7 +919,11 @@
                 datasets[libraryIndex]['lines'] = { show: true };
                 datasets[libraryIndex]['points'] = { show: true };
               }
-              datasets[libraryIndex]['data'].push([benchmarkIndex, testData[benchmark][library].avg]);
+              var avg = testData[benchmark][library].avg;
+              datasets[libraryIndex]['data'].push([benchmarkIndex, avg]);
+              if (avg && avg > maxTime) {
+                maxTime = avg;
+              }
               libraryIndex++;
             }
             benchmarkIndex++;
@@ -935,7 +940,7 @@
                 noTics: benchmarks.length,
                 min: 0, max: benchmarks.length - 1,
               },
-              yaxis:{ title: 'Time (ms)', min: 0, max: 50 },
+              yaxis:{ title: 'Time (ms)', min: 0, max: maxTime },
               title: "WebGL Matrix Library Benchmark",
               subtitle: "Averaged over 10 runs of 50,000 iterations.",
               grid:{ verticalLines: true, backgroundColor: 'white' },


### PR DESCRIPTION
The graph was hardcoded to 50ms max so if you use a slow machine
nothing is on the graph. This patch changes it to set the
vertical range to the longest time.

I'm not sure this is the best way because if just a a couple of tests run long everything else is squished. Maybe another patch could make it sort the times and throw away the top 20% of them before choosing a range. Just an idea
